### PR TITLE
Replace cat with message

### DIFF
--- a/R/BGLR.R
+++ b/R/BGLR.R
@@ -140,7 +140,7 @@ setLT.BRR=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,groups,nGroups
 
 	if(verbose)
 	{
-		cat(paste(" Degree of freedom of LP ",j,"  set to default value (",LT$df0,").\n",sep=""))
+		message(" Degree of freedom of LP ",j,"  set to default value (",LT$df0,").")
 	}
     }
 
@@ -160,7 +160,7 @@ setLT.BRR=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,groups,nGroups
 	
 	if(verbose)
 	{
-		cat(paste(" Scale parameter of LP ",j,"  set to default value (",LT$S0,") .\n",sep=""))
+		message(" Scale parameter of LP ",j,"  set to default value (",LT$S0,") .")
 	}
     }
 
@@ -187,11 +187,11 @@ setLT.BRR=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,groups,nGroups
 
     if(LT$lower_tri)
     {
-	cat(paste("You have provided a lower triangular matrix for LP ", j,"\n"))
-	cat("Checking dimmensions...\n")
+	message("You have provided a lower triangular matrix for LP ", j)
+	message("Checking dimmensions...")
 	if(ncol(LT$X)==nrow(LT$X))
 	{
-		cat("Ok.")
+		message("Ok.")
 		LT$X=LT$X[lower.tri(LT$X,diag=TRUE)]
         }
     }else{
@@ -255,7 +255,7 @@ setLT.BRR_sets=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,t
     if(is.null(LT$df0)){
 		LT$df0=5
 		if(verbose){
-			cat(paste(" Degree of freedom of LP ",j,"  set to default value (",LT$df0,").\n",sep=""))
+			message(" Degree of freedom of LP ",j,"  set to default value (",LT$df0,").")
 		}
     }
 
@@ -269,7 +269,7 @@ setLT.BRR_sets=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,t
 		LT$MSx=sum(LT$x2)/n-sumMeanXSq       
 		LT$S0=((var(y,na.rm=TRUE)*LT$R2)/(LT$MSx))*(LT$df0+2) 
 		if(verbose){ 
-			cat(paste(" Scale parameter of LP ",j,"  set to default value (",LT$S0,") .\n",sep=""))
+			message(" Scale parameter of LP ",j,"  set to default value (",LT$S0,") .")
 		}
     }
     
@@ -360,7 +360,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
 		LT$lambda=sqrt(LT$lambda2)
 		if(verbose)
 		{
-			cat(paste(" Initial value of lambda in LP ",j," was set to default value (",LT$lambda,")\n",sep=""))
+			message(" Initial value of lambda in LP ",j," was set to default value (",LT$lambda,")")
 		}
     }else{
 	if(LT$lambda<0) stop(" lambda should be positive");
@@ -373,7 +373,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
 		LT$type="gamma"
 		if(verbose)
 		{
-			cat(paste("  By default, the prior density of lambda^2 in the LP ",j,"  was set to gamma.\n",sep=""))
+			message("  By default, the prior density of lambda^2 in the LP ",j,"  was set to gamma.")
 		}
     }else{
 		if(!LT$type%in%c("gamma","beta","FIXED")) stop(" The prior for lambda^2 should be gamma, beta or a point of mass (i.e., fixed lambda).")
@@ -385,7 +385,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
 			 LT$shape=1.1
 			 if(verbose)
 			 {
-			 	cat(paste("  shape parameter in LP ",j," was missing and was set to ",LT$shape,"\n",sep=""))
+			 	message("  shape parameter in LP ",j," was missing and was set to ",LT$shape)
 			 }
 		}
 		
@@ -394,7 +394,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
 			 LT$rate=(LT$shape-1)/LT$lambda2
 			 if(verbose)
 			 {
-			 	cat(paste("  rate parameter in LP ",j," was missing and was set to ",LT$rate,"\n",sep=""))
+			 	message("  rate parameter in LP ",j," was missing and was set to ",LT$rate)
 			 }
 		}	
     }
@@ -406,7 +406,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
     			LT$probIn=0.5
 			if(verbose)
 			{
-    				cat(paste("  probIn in LP ",j," was missing and was set to ",LT$probIn,"\n",sep=""))
+    				message("  probIn in LP ",j," was missing and was set to ",LT$probIn)
 			}
   		}
 
@@ -415,7 +415,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
     			LT$counts=2
 			if(verbose)
 			{
-    				cat(paste("  Counts in LP ",j," was missing and was set to ",LT$counts,"\n",sep=""))
+    				message("  Counts in LP ",j," was missing and was set to ",LT$counts)
 			}
   		} 
 
@@ -427,7 +427,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
 		    LT$max=10*LT$lambda
 		    if(verbose)
 		    {
-		    	cat(paste("  max parameter in LP ",j," was missing and was set to ",LT$max,"\n",sep=""))
+		    	message("  max parameter in LP ",j," was missing and was set to ",LT$max)
 		    }
 		}
     }
@@ -510,7 +510,7 @@ setLT.RKHS=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose)
     }else{
 	if(any(weights!=1))
         { 
-		cat(paste(" Warning, in LT ",j," Eigen decomposition was provided, and the model involves weights. Note: You should have weighted the kernel before computing eigen(K).\n",sep="")) 
+		message(" Warning, in LT ",j," Eigen decomposition was provided, and the model involves weights. Note: You should have weighted the kernel before computing eigen(K).") 
         }
     }
     
@@ -521,7 +521,7 @@ setLT.RKHS=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose)
        LT$tolD = 1e-10
        if(verbose)
        {
-       		cat(paste("  Default value of minimum eigenvalue in LP ",j," was set to ",LT$tolD,"\n",sep=""))
+       		message("  Default value of minimum eigenvalue in LP ",j," was set to ",LT$tolD)
        }
     }
     
@@ -537,7 +537,7 @@ setLT.RKHS=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose)
       LT$df0 = 5
       if(verbose)
       {
-      	cat(paste("  default value of df0 in LP ",j," was missing and was set to ",LT$df0,"\n",sep=""))
+      	message("  default value of df0 in LP ",j," was missing and was set to ",LT$df0)
       }
     }
    
@@ -554,7 +554,7 @@ setLT.RKHS=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose)
 
 	  if(verbose)
 	  {
-             cat(paste("  default value of S0 in LP ",j," was missing and was set to ",LT$S0,"\n",sep=""))
+             message("  default value of S0 in LP ",j," was missing and was set to ",LT$S0)
 	  }
     }
     
@@ -627,7 +627,7 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
     LT$R2=R2/nLT
     if(verbose)
     {
-      cat(paste("  R2 in LP ",j," was missing and was set to ",LT$R2,"\n",sep=""))
+      message("  R2 in LP ",j," was missing and was set to ",LT$R2)
     }
   }
 
@@ -638,7 +638,7 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
     LT$df0= 5
     if(verbose)
     {
-    	cat(paste("  DF in LP ",j," was missing and was set to ",LT$df0,"\n",sep=""))
+    	message("  DF in LP ",j," was missing and was set to ",LT$df0)
     }
   }
 
@@ -649,7 +649,7 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
     LT$probIn=0.5
     if(verbose)
     {	
-       cat(paste("  probIn in LP ",j," was missing and was set to ",LT$probIn,"\n",sep=""))
+       message("  probIn in LP ",j," was missing and was set to ",LT$probIn)
     }
   } 
 
@@ -660,7 +660,7 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
     LT$counts=10
     if(verbose)
     {
-       cat(paste("  Counts in LP ",j," was missing and was set to ",LT$counts,"\n",sep=""))
+       message("  Counts in LP ",j," was missing and was set to ",LT$counts)
     }
   }
 
@@ -675,7 +675,7 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
      LT$S0=var(y, na.rm = TRUE)*LT$R2/(LT$MSx)*(LT$df0+2)/LT$probIn
      if(verbose)
      {
-     	cat(paste(" Scale parameter in LP ",j," was missing and was set to ",LT$S0,"\n",sep=""))
+     	message(" Scale parameter in LP ",j," was missing and was set to ",LT$S0)
      }
   }
  
@@ -773,7 +773,7 @@ setLT.BayesA=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose,thi
      LT$df0 = 5 
      if(verbose)
      { 
-     	cat(paste("  DF in LP ",j," was missing and was set to ",LT$df0,".\n",sep=""))
+     	message("  DF in LP ",j," was missing and was set to ",LT$df0,".")
      }
   }
   if(is.null(LT$R2))
@@ -781,7 +781,7 @@ setLT.BayesA=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose,thi
     LT$R2=R2/nLT
     if(verbose)
     {
-    	cat(paste("  R2 in LP ",j," was missing and was set to ",LT$R2,"\n",sep=""))
+    	message("  R2 in LP ",j," was missing and was set to ",LT$R2)
     }
   }
 
@@ -792,7 +792,7 @@ setLT.BayesA=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose,thi
      LT$S0 = var(y, na.rm = TRUE)*LT$R2/(LT$MSx)*(LT$df0+2)
      if(verbose)
      {
-     	cat(paste(" Scale parameter in LP ",j," was missing and was set to ",LT$S0,"\n",sep=""))
+     	message(" Scale parameter in LP ",j," was missing and was set to ",LT$S0)
      }
   }
 
@@ -852,20 +852,20 @@ setLT.BayesA=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose,thi
 #Just the welcome function that will appear every time that your run the program
 welcome=function()
 {
-  cat("\n");
-  cat("#--------------------------------------------------------------------#\n");
-  cat("#        _\\\\|//_                                                     #\n");
-  cat("#       (` o-o ')      BGLR v1.0.5 beta                            #\n");
-  cat("#------ooO-(_)-Ooo---------------------------------------------------#\n");
-  cat("#                      Bayesian Generalized Linear Regression        #\n");
-  cat("#                      Gustavo de los Campos, gdeloscampos@gmail.com #\n");
-  cat("#    .oooO     Oooo.   Paulino Perez, perpdgo@gmail.com              #\n");
-  cat("#    (   )     (   )   May, 2017                                   #\n");
-  cat("#_____\\ (_______) /_________________________________________________ #\n");
-  cat("#      \\_)     (_/                                                   #\n");
-  cat("#                                                                    #\n");
-  cat("#------------------------------------------------------------------- #\n");
-  cat("\n");
+  message();
+  message("#--------------------------------------------------------------------#");
+  message("#        _\\\\|//_                                                     #");
+  message("#       (` o-o ')      BGLR v1.0.5 beta                            #");
+  message("#------ooO-(_)-Ooo---------------------------------------------------#");
+  message("#                      Bayesian Generalized Linear Regression        #");
+  message("#                      Gustavo de los Campos, gdeloscampos@gmail.com #");
+  message("#    .oooO     Oooo.   Paulino Perez, perpdgo@gmail.com              #");
+  message("#    (   )     (   )   May, 2017                                   #");
+  message("#_____\\ (_______) /_________________________________________________ #");
+  message("#      \\_)     (_/                                                   #");
+  message("#                                                                    #");
+  message("#------------------------------------------------------------------- #");
+  message();
 }
 ##################################################################################################
 
@@ -1134,13 +1134,13 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
         unlink(fname)
     }
     else {
-        cat(" Note: samples will be appended to existing files. \n")
+        message(" Note: samples will be appended to existing files.")
     }
 
     fileOutMu = file(description = fname, open = "w")
 
     if (response_type == "ordinal") {
-        if(verbose){ cat(" Prior for residual is not necessary, if you provided it, it will be ignored\n")}
+        if(verbose){ message(" Prior for residual is not necessary, if you provided it, it will be ignored")}
         if (any(weights != 1)) stop(" Weights are not supported")
        
         countsZ=table(z)
@@ -1284,7 +1284,7 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
             for (j in 1:nLT) {
                 ## Fixed effects ####################################################################
                 if (ETA[[j]]$model == "FIXED") {
-                  #cat("varB=",ETA[[j]]$varB,"\n");
+                  #message("varB=",ETA[[j]]$varB);
                   varBj = rep(ETA[[j]]$varB, ETA[[j]]$p)
                   if(!is.null(groups)){
                         ans = .Call("sample_beta_groups", n, ETA[[j]]$p, ETA[[j]]$X, ETA[[j]]$x2, ETA[[j]]$b,
@@ -1752,10 +1752,10 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
         }#end of saving samples and computing running means
 
         if (verbose) {
-            cat("---------------------------------------\n")
+            message("---------------------------------------")
             tmp = proc.time()[3]
-            cat(c(paste(c("  Iter=", "Time/Iter="), round(c(i, c(tmp - time)), 3), sep = "")), "\n")
-            cat("  VarE=",round(varE,3),"\n")
+            message("  Iter=", i, " Time/Iter=", round(tmp - time, 3))
+            message("  VarE=",round(varE,3))
             time = tmp
         }
     }#end of Gibbs sampler
@@ -1938,16 +1938,16 @@ BLR=function (y, XF = NULL, XR = NULL, XL = NULL, GF = list(ID = NULL,
     ETA = list()
     nLT = 0
 
-    cat("This implementation is a simplified interface for the more general\n")
-    cat("function BGLR, we keep it for backward compatibility with our package BLR\n")
+    message("This implementation is a simplified interface for the more general")
+    message("function BGLR, we keep it for backward compatibility with our package BLR")
 
     warning("thin2 parameter is not used any more and will be deleted in next releases",immediate. = TRUE);
    
-    cat("Setting parameters for BGLR...\n")
+    message("Setting parameters for BGLR...")
     if (is.null(prior)) {
-        cat("===============================================================\n")
-        cat("No prior was provided, BGLR will be running with improper priors.\n")
-        cat("===============================================================\n")
+        message("===============================================================")
+        message("No prior was provided, BGLR will be running with improper priors.")
+        message("===============================================================")
         prior = list(varE = list(S = NULL, df = 1), varBR = list(S = 0, 
             df = 0), varU = list(S = 0, df = 0), lambda = list(shape = 0, 
             rate = 0, type = "random", value = 50))
@@ -1965,13 +1965,13 @@ BLR=function (y, XF = NULL, XR = NULL, XL = NULL, GF = list(ID = NULL,
         nLT = nLT + 1
         if (prior$lambda$type == "random") {
             if (is.null(prior$lambda$rate)) {
-                cat("Setting prior for lambda^2 to beta\n")
+                message("Setting prior for lambda^2 to beta")
                 prior$lambda$type = "beta"
                 prior$lambda$shape = NULL
                 prior$lambda$rate = NULL
             }
             else {
-                cat("Setting prior for lambda^2 to gamma\n")
+                message("Setting prior for lambda^2 to gamma")
                 prior$lambda$type = "gamma"
                 prior$lambda$max = NULL
                 prior$lambda$shape1 = NULL
@@ -1997,8 +1997,8 @@ BLR=function (y, XF = NULL, XR = NULL, XL = NULL, GF = list(ID = NULL,
         warning("IDs are not used any more and will be deleted in next releases...",immediate. = TRUE) 
     }
 
-    cat("Finish setting parameters for BGLR\n")
-    cat("Fitting model using BGLR...\n")
+    message("Finish setting parameters for BGLR")
+    message("Fitting model using BGLR...")
     out = BGLR(y = y, ETA = ETA, df0 = prior$varE$df, S0 = prior$varE$S, 
                nIter = nIter, burnIn = burnIn, thin = thin, saveAt = saveAt, 
                weights = weights)

--- a/R/BGLR.R
+++ b/R/BGLR.R
@@ -926,12 +926,12 @@ metropLambda=function (tau2, lambda, shape1 = 1.2, shape2 = 1.2, max = 200, ncp 
   assign(".BGLR.version", BGLR.version, pos=match("package:BGLR", search()))
   if(interactive())
   {
-    packageStartupMessage("# Package Bayesian Generalized Regression (BGLR), ", BGLR.version, ".",appendLF=TRUE)
-    packageStartupMessage("# Gustavo de los Campos & Paulino Perez-Rodriguez",appendLF=TRUE)
-    packageStartupMessage("# Support provided by the U.S., National Institutes of Health (NIH)", appendLF=TRUE)
-    packageStartupMessage("# (Grant: R01GM101219, NIGMS)", appendLF=TRUE)
-    packageStartupMessage("# and by the International Maize and Wheat Improvement Center (CIMMyT).",appendLF=TRUE)                        
-    packageStartupMessage("# Type 'help(BGLR)' for summary information",appendLF=TRUE)
+    packageStartupMessage("# Package Bayesian Generalized Regression (BGLR), ", BGLR.version, ".")
+    packageStartupMessage("# Gustavo de los Campos & Paulino Perez-Rodriguez")
+    packageStartupMessage("# Support provided by the U.S., National Institutes of Health (NIH)")
+    packageStartupMessage("# (Grant: R01GM101219, NIGMS)")
+    packageStartupMessage("# and by the International Maize and Wheat Improvement Center (CIMMyT).")
+    packageStartupMessage("# Type 'help(BGLR)' for summary information")
   }
   invisible()
 }

--- a/R/BGLR.R
+++ b/R/BGLR.R
@@ -45,12 +45,12 @@ setLT.Fixed=function(LT,n,j,y,weights,nLT,saveAt,rmExistingFiles,groups,nGroups)
 	
     if(any(is.na(LT$X)))
     { 
-	stop(paste(" LP ",j," has NAs in X",sep=""))
+	stop(" LP ",j," has NAs in X")
     }
 
     if(nrow(LT$X)!=n)
     {
-        stop(paste(" Number of rows of LP ",j,"  not equal to the number of phenotypes.",sep=""))
+        stop(" Number of rows of LP ",j,"  not equal to the number of phenotypes.")
     }
 
     #weight inputs if necessary
@@ -107,12 +107,12 @@ setLT.BRR=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,groups,nGroups
 	
     if(any(is.na(LT$X)))
     { 
-      stop(paste(" LP ",j," has NAs in X",sep=""))
+      stop(" LP ",j," has NAs in X")
     }
     
     if(nrow(LT$X)!=n)
     {
-      stop(paste(" Number of rows of LP ",j,"  not equal to the number of phenotypes.",sep=""))
+      stop(" Number of rows of LP ",j,"  not equal to the number of phenotypes.")
     }   
 
     #Weight inputs if necessary
@@ -239,11 +239,11 @@ setLT.BRR_sets=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,t
   	if(LT$n_sets>=LT$p){ stop("The number of sets is greater or equal than the number of effects!") }
     
     if(any(is.na(LT$X))){ 
-      stop(paste(" LP ",j," has NAs in X",sep=""))
+      stop(" LP ",j," has NAs in X")
     }
     
     if(nrow(LT$X)!=n){
-      stop(paste(" Number of rows of LP ",j,"  not equal to the number of phenotypes.",sep=""))
+      stop(" Number of rows of LP ",j,"  not equal to the number of phenotypes.")
     }   
 
     #Weight inputs if necessary
@@ -325,12 +325,12 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
 		
     if(any(is.na(LT$X)))
     {
-       stop(paste("LP ",j," has NAs in X",sep=""))
+       stop("LP ",j," has NAs in X")
     }
 
     if(nrow(LT$X)!=n)
     {
-        stop(paste(" Number of rows of LP ",j,"  not equal to the number of phenotypes.",sep=""))
+        stop(" Number of rows of LP ",j,"  not equal to the number of phenotypes.")
     } 
 
     #Wheight inputs if necessary
@@ -481,13 +481,13 @@ setLT.RKHS=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose)
     #Checking inputs
     if(is.null(LT$V))
     {
-        if(is.null(LT$K)) stop(paste(" Kernel for linear term ",j, " was not provided, specify it with list(K=?,model='RKHS'), where ? is the kernel matrix",sep=""))
+        if(is.null(LT$K)) stop(" Kernel for linear term ",j, " was not provided, specify it with list(K=?,model='RKHS'), where ? is the kernel matrix")
 
 	LT$K = as.matrix(LT$K)
 
-        if(class(LT$K)!="matrix") stop(paste(" Kernel for linear term ",j, " should be a matrix, the kernel provided is of class ", class(LT$K),sep=" "))
+        if(class(LT$K)!="matrix") stop(" Kernel for linear term ",j, " should be a matrix, the kernel provided is of class ", class(LT$K))
 
-        if(nrow(LT$K)!=ncol(LT$K)) stop(paste(" Kernel for linear term ",j, " is not a square matrix",sep=""))
+        if(nrow(LT$K)!=ncol(LT$K)) stop(" Kernel for linear term ",j, " is not a square matrix")
 
 	#This code was rewritten to speed up computations
         #T = diag(weights)   
@@ -619,8 +619,8 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
   LT$MSx=sum(LT$x2)/n-sumMeanXSq
 
   
-  if(any(is.na(LT$X))){ stop(paste("LP ",j," has NAs in X",sep=""))}
-  if(nrow(LT$X)!=n){stop(paste("   Number of rows of LP ",j,"  not equal to the number of phenotypes.",sep=""))}
+  if(any(is.na(LT$X))){ stop("LP ",j," has NAs in X")}
+  if(nrow(LT$X)!=n){stop("   Number of rows of LP ",j,"  not equal to the number of phenotypes.")}
   
   if(is.null(LT$R2))
   {
@@ -671,7 +671,7 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
   #marker effects
   if(is.null(LT$S0))
   {
-     if(LT$df0<=0) stop(paste("df0>0 in ",model," in order to set S0",sep=""));
+     if(LT$df0<=0) stop("df0>0 in ",model," in order to set S0");
      LT$S0=var(y, na.rm = TRUE)*LT$R2/(LT$MSx)*(LT$df0+2)/LT$probIn
      if(verbose)
      {
@@ -926,7 +926,7 @@ metropLambda=function (tau2, lambda, shape1 = 1.2, shape2 = 1.2, max = 200, ncp 
   assign(".BGLR.version", BGLR.version, pos=match("package:BGLR", search()))
   if(interactive())
   {
-    packageStartupMessage(paste("# Package Bayesian Generalized Regression (BGLR), ", BGLR.version, ". ",sep=""),appendLF=TRUE)
+    packageStartupMessage("# Package Bayesian Generalized Regression (BGLR), ", BGLR.version, ".",appendLF=TRUE)
     packageStartupMessage("# Gustavo de los Campos & Paulino Perez-Rodriguez",appendLF=TRUE)
     packageStartupMessage("# Support provided by the U.S., National Institutes of Health (NIH)", appendLF=TRUE)
     packageStartupMessage("# (Grant: R01GM101219, NIGMS)", appendLF=TRUE)
@@ -1145,7 +1145,7 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
        
         countsZ=table(z)
 
-        if (nclass <= 1) stop(paste(" Data vector y has only ", nclass, " differente values, it should have at least 2 different values"))
+        if (nclass <= 1) stop(" Data vector y has only ", nclass, " differente values, it should have at least 2 different values")
         threshold=qnorm(p=c(0,cumsum(as.vector(countsZ)/n)))
           
         y = rtrun(mu =0, sigma = 1, a = threshold[z], b = threshold[ (z + 1)])
@@ -1225,13 +1225,13 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
 
             if (!(ETA[[i]]$model %in% c("FIXED", "BRR", "BL", "BayesA", "BayesB","BayesC", "RKHS","BRR_sets"))) 
             {
-                stop(paste(" Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented (note: evaluation is case sensitive).", sep = ""))
+                stop(" Error in ETA[[", i, "]] model ", ETA[[i]]$model, " not implemented (note: evaluation is case sensitive).")
                 
             }
 
             if(!is.null(groups))
             {
-		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop(paste(" Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented for groups", sep = ""))
+		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop(" Error in ETA[[", i, "]] model ", ETA[[i]]$model, " not implemented for groups")
             }
 
 
@@ -1353,11 +1353,11 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$tau2 = 1/tmp
                     }
                     else {
-                      warning(paste("tau2 was not updated in iteration",i, "due to numeric problems with beta\n",sep=" "),immediate. = TRUE)
+                      warning("tau2 was not updated in iteration ",i, " due to numeric problems with beta",immediate. = TRUE)
                     }
                   }
                   else {
-                    warning(paste("tau2 was not updated  in iteration",i,"due to numeric problems with beta\n",sep=" "),immediate. = TRUE)
+                    warning("tau2 was not updated  in iteration ",i," due to numeric problems with beta",immediate. = TRUE)
                   }
 
                   #Update lambda 
@@ -1369,7 +1369,7 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$lambda = sqrt(ETA[[j]]$lambda2)
                     }
                     else {
-                      warning(paste("lambda was not updated in iteration",i, "due to numeric problems with beta\n",sep=" "),immediate. = TRUE)
+                      warning("lambda was not updated in iteration ",i, " due to numeric problems with beta",immediate. = TRUE)
                     }
                   }
 
@@ -1941,7 +1941,7 @@ BLR=function (y, XF = NULL, XR = NULL, XL = NULL, GF = list(ID = NULL,
     cat("This implementation is a simplified interface for the more general\n")
     cat("function BGLR, we keep it for backward compatibility with our package BLR\n")
 
-    warning("thin2 parameter is not used any more and will be deleted in next releases\n",immediate. = TRUE);
+    warning("thin2 parameter is not used any more and will be deleted in next releases",immediate. = TRUE);
    
     cat("Setting parameters for BGLR...\n")
     if (is.null(prior)) {
@@ -1994,7 +1994,7 @@ BLR=function (y, XF = NULL, XR = NULL, XL = NULL, GF = list(ID = NULL,
         nLT = nLT + 1
         ETA[[nLT]] = list(K = GF$A, model = "RKHS", df0 = prior$varU$df, 
             S0 = prior$varU$S)
-        warning("IDs are not used any more and will be deleted in next releases...\n",immediate. = TRUE) 
+        warning("IDs are not used any more and will be deleted in next releases...",immediate. = TRUE) 
     }
 
     cat("Finish setting parameters for BGLR\n")

--- a/R/BGLR.R
+++ b/R/BGLR.R
@@ -27,7 +27,7 @@ set.X=function(LT)
     		if(Xint > 0L) X = X[, -Xint, drop=FALSE]
 	   }
 	}
-	if(flag) stop("Unable to build incidence matrix, wrong formula or data\n")
+	if(flag) stop("Unable to build incidence matrix, wrong formula or data")
 	return(X)
 }
 
@@ -153,7 +153,7 @@ setLT.BRR=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,groups,nGroups
     #Default scale parameter for the prior assigned to the variance of marker effects
     if(is.null(LT$S0))
     {
-        if(LT$df0<=0) stop("df0>0 in BRR in order to set S0\n")
+        if(LT$df0<=0) stop("df0>0 in BRR in order to set S0")
 
 	LT$MSx=sum(LT$x2)/n-sumMeanXSq       
 	LT$S0=((var(y,na.rm=TRUE)*LT$R2)/(LT$MSx))*(LT$df0+2)  
@@ -229,14 +229,14 @@ setLT.BRR_sets=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,t
     LT$p=ncol(LT$X)
     LT$colNames=colnames(LT$X)
 
-    if(is.null(LT$sets)) stop("Argument sets (a vector grouping effects into sets) is required in BRR_sets\n");
-  	if(length(LT$sets)!=LT$p){ stop(" The length of sets must be equal to the number of predictors\n") }
+    if(is.null(LT$sets)) stop("Argument sets (a vector grouping effects into sets) is required in BRR_sets");
+  	if(length(LT$sets)!=LT$p){ stop(" The length of sets must be equal to the number of predictors") }
 	
 	LT$sets<-as.integer(factor(LT$sets,ordered=TRUE,levels=unique(LT$sets)))
 		
 	LT$n_sets=length(unique(LT$sets))	
   	
-  	if(LT$n_sets>=LT$p){ stop("The number of sets is greater or equal than the number of effects!\n") }
+  	if(LT$n_sets>=LT$p){ stop("The number of sets is greater or equal than the number of effects!") }
     
     if(any(is.na(LT$X))){ 
       stop(paste(" LP ",j," has NAs in X",sep=""))
@@ -264,7 +264,7 @@ setLT.BRR_sets=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,t
     }
 
     if(is.null(LT$S0))    {
-        if(LT$df0<=0) stop("df0 must be greater than 0 \n")
+        if(LT$df0<=0) stop("df0 must be greater than 0")
 
 		LT$MSx=sum(LT$x2)/n-sumMeanXSq       
 		LT$S0=((var(y,na.rm=TRUE)*LT$R2)/(LT$MSx))*(LT$df0+2) 
@@ -351,7 +351,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
     { 
     	if(LT$lambda<0)
         {
-		stop(" lambda should be positive\n")
+		stop(" lambda should be positive")
 	}  
     }
     if(is.null(LT$lambda))
@@ -363,7 +363,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
 			cat(paste(" Initial value of lambda in LP ",j," was set to default value (",LT$lambda,")\n",sep=""))
 		}
     }else{
-	if(LT$lambda<0) stop(" lambda should be positive\n");
+	if(LT$lambda<0) stop(" lambda should be positive");
         LT$lambda2=LT$lambda^2
     }
 	
@@ -376,7 +376,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
 			cat(paste("  By default, the prior density of lambda^2 in the LP ",j,"  was set to gamma.\n",sep=""))
 		}
     }else{
-		if(!LT$type%in%c("gamma","beta","FIXED")) stop(" The prior for lambda^2 should be gamma, beta or a point of mass (i.e., fixed lambda).\n")
+		if(!LT$type%in%c("gamma","beta","FIXED")) stop(" The prior for lambda^2 should be gamma, beta or a point of mass (i.e., fixed lambda).")
     }
     if(LT$type=="gamma")
     {
@@ -481,13 +481,13 @@ setLT.RKHS=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose)
     #Checking inputs
     if(is.null(LT$V))
     {
-        if(is.null(LT$K)) stop(paste(" Kernel for linear term ",j, " was not provided, specify it with list(K=?,model='RKHS'), where ? is the kernel matrix\n",sep=""))
+        if(is.null(LT$K)) stop(paste(" Kernel for linear term ",j, " was not provided, specify it with list(K=?,model='RKHS'), where ? is the kernel matrix",sep=""))
 
 	LT$K = as.matrix(LT$K)
 
-        if(class(LT$K)!="matrix") stop(paste(" Kernel for linear term ",j, " should be a matrix, the kernel provided is of class ", class(LT$K),"\n",sep=" "))
+        if(class(LT$K)!="matrix") stop(paste(" Kernel for linear term ",j, " should be a matrix, the kernel provided is of class ", class(LT$K),sep=" "))
 
-        if(nrow(LT$K)!=ncol(LT$K)) stop(paste(" Kernel for linear term ",j, " is not a square matrix\n",sep=""))
+        if(nrow(LT$K)!=ncol(LT$K)) stop(paste(" Kernel for linear term ",j, " is not a square matrix",sep=""))
 
 	#This code was rewritten to speed up computations
         #T = diag(weights)   
@@ -671,7 +671,7 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
   #marker effects
   if(is.null(LT$S0))
   {
-     if(LT$df0<=0) stop(paste("df0>0 in ",model," in order to set S0\n",sep=""));
+     if(LT$df0<=0) stop(paste("df0>0 in ",model," in order to set S0",sep=""));
      LT$S0=var(y, na.rm = TRUE)*LT$R2/(LT$MSx)*(LT$df0+2)/LT$probIn
      if(verbose)
      {
@@ -788,7 +788,7 @@ setLT.BayesA=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose,thi
   #Defuault scale parameter for the prior assigned to the variance of markers
   if(is.null(LT$S0))
   {
-     if(LT$df0<=0) stop("df0>0 in BayesA in order to set S0\n")
+     if(LT$df0<=0) stop("df0>0 in BayesA in order to set S0")
      LT$S0 = var(y, na.rm = TRUE)*LT$R2/(LT$MSx)*(LT$df0+2)
      if(verbose)
      {
@@ -1054,7 +1054,7 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
     }
 
     IDs=names(y)
-    if (!(response_type %in% c("gaussian", "ordinal")))  stop(" Only gaussian and ordinal responses are allowed\n")
+    if (!(response_type %in% c("gaussian", "ordinal")))  stop(" Only gaussian and ordinal responses are allowed")
 
     if (saveAt == "") {
         saveAt = paste(getwd(), "/", sep = "")
@@ -1077,7 +1077,7 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
 		groupLabels=names(countGroups)
                 groups=as.integer(groups)
                 ggg=as.integer(groups-1);  #In C we begin to count in 0
-		if(sum(countGroups)!=n) stop("length of groups and y differs, NA's not allowed in groups\n");	
+		if(sum(countGroups)!=n) stop("length of groups and y differs, NA's not allowed in groups");	
     }
 
     if(response_type=="ordinal")
@@ -1086,7 +1086,7 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
     	y=factor(y,ordered=TRUE)
         lev=levels(y)
         nclass=length(lev)
-        if(nclass==n) stop("The number of classes in y must be smaller than the number of observations\n");
+        if(nclass==n) stop("The number of classes in y must be smaller than the number of observations");
 
         y=as.integer(y)
         z=y  
@@ -1120,8 +1120,8 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
         if ((!is.null(a)) | (!is.null(b))) 
         {
             Censored = TRUE
-            if ((length(a) != n) | (length(b) != n)) stop(" y, a and b must have the same dimension\n")
-            if (any(weights != 1)) stop(" Weights are only implemented for Gausian uncensored responses\n")
+            if ((length(a) != n) | (length(b) != n)) stop(" y, a and b must have the same dimension")
+            if (any(weights != 1)) stop(" Weights are only implemented for Gausian uncensored responses")
         }
         mu = weighted.mean(x = y, w = weights, na.rm = TRUE)
     }
@@ -1141,11 +1141,11 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
 
     if (response_type == "ordinal") {
         if(verbose){ cat(" Prior for residual is not necessary, if you provided it, it will be ignored\n")}
-        if (any(weights != 1)) stop(" Weights are not supported \n")
+        if (any(weights != 1)) stop(" Weights are not supported")
        
         countsZ=table(z)
 
-        if (nclass <= 1) stop(paste(" Data vector y has only ", nclass, " differente values, it should have at least 2 different values\n"))
+        if (nclass <= 1) stop(paste(" Data vector y has only ", nclass, " differente values, it should have at least 2 different values"))
         threshold=qnorm(p=c(0,cumsum(as.vector(countsZ)/n)))
           
         y = rtrun(mu =0, sigma = 1, a = threshold[z], b = threshold[ (z + 1)])
@@ -1231,7 +1231,7 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
 
             if(!is.null(groups))
             {
-		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop(paste(" Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented for groups\n", sep = ""))
+		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop(paste(" Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented for groups", sep = ""))
             }
 
 

--- a/R/BGLR2.R
+++ b/R/BGLR2.R
@@ -102,7 +102,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
        
         countsZ=table(z)
 
-        if (nclass <= 1) stop(paste(" Data vector y has only ", nclass, " differente values, it should have at least 2 different values"))
+        if (nclass <= 1) stop(" Data vector y has only ", nclass, " differente values, it should have at least 2 different values")
         threshold=qnorm(p=c(0,cumsum(as.vector(countsZ)/n)))
           
         y = rtrun(mu =0, sigma = 1, a = threshold[z], b = threshold[ (z + 1)])
@@ -181,13 +181,13 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
 
             if (!(ETA[[i]]$model %in% c("FIXED", "BRR", "BL", "BayesA", "BayesB","BayesC", "RKHS","BRR_sets"))) 
             {
-                stop(paste(" Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented (note: evaluation is case sensitive).", sep = ""))
+                stop(" Error in ETA[[", i, "]] model ", ETA[[i]]$model, " not implemented (note: evaluation is case sensitive).")
                 
             }
 
             if(!is.null(groups))
             {
-		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop(paste(" Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented for groups", sep = ""))
+		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop(" Error in ETA[[", i, "]] model ", ETA[[i]]$model, " not implemented for groups")
             }
 
 
@@ -425,11 +425,11 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$tau2 = 1/tmp
                     }
                     else {
-                      warning(paste("tau2 was not updated in iteration",i, "due to numeric problems with beta\n",sep=" "),immediate. = TRUE)
+                      warning("tau2 was not updated in iteration ",i, " due to numeric problems with beta",immediate. = TRUE)
                     }
                   }
                   else {
-                    warning(paste("tau2 was not updated  in iteration",i,"due to numeric problems with beta\n",sep=" "),immediate. = TRUE)
+                    warning("tau2 was not updated  in iteration ",i," due to numeric problems with beta",immediate. = TRUE)
                   }
 
                   #Update lambda 
@@ -441,7 +441,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$lambda = sqrt(ETA[[j]]$lambda2)
                     }
                     else {
-                      warning(paste("lambda was not updated in iteration",i, "due to numeric problems with beta\n",sep=" "),immediate. = TRUE)
+                      warning("lambda was not updated in iteration ",i, " due to numeric problems with beta",immediate. = TRUE)
                     }
                   }
 

--- a/R/BGLR2.R
+++ b/R/BGLR2.R
@@ -91,13 +91,13 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
         unlink(fname)
     }
     else {
-        if(verbose) {cat(" Note: samples will be appended to existing files. \n") }
+        if(verbose) {message(" Note: samples will be appended to existing files.") }
     }
 
     fileOutMu = file(description = fname, open = "w")
 
     if (response_type == "ordinal") {
-        if(verbose){ cat(" Prior for residual is not necessary, if you provided it, it will be ignored\n")}
+        if(verbose){ message(" Prior for residual is not necessary, if you provided it, it will be ignored")}
         if (any(weights != 1)) stop(" Weights are not supported")
        
         countsZ=table(z)
@@ -361,7 +361,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
             for (j in 1:nLT) {
                 ## Fixed effects ####################################################################
                 if (ETA[[j]]$model == "FIXED") {
-                  #cat("varB=",ETA[[j]]$varB,"\n");
+                  #message("varB=",ETA[[j]]$varB);
                   varBj = rep(ETA[[j]]$varB, ETA[[j]]$p)
                   if(!is.null(groups)){
                         ans = .Call("sample_beta_groups", n, ETA[[j]]$p, ETA[[j]]$X, ETA[[j]]$x2, ETA[[j]]$b,
@@ -823,10 +823,10 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
         }#end of saving samples and computing running means
 
         if (verbose) {
-            cat("---------------------------------------\n")
+            message("---------------------------------------")
             tmp = proc.time()[3]
-            cat(c(paste(c("  Iter=", "Time/Iter="), round(c(i, c(tmp - time)), 3), sep = "")), "\n")
-            cat("  VarE=",round(varE,3),"\n")
+            message("  Iter=", i, " Time/Iter=", round(tmp - time, 3))
+            message("  VarE=",round(varE,3))
             time = tmp
         }
     }#end of Gibbs sampler

--- a/R/BGLR2.R
+++ b/R/BGLR2.R
@@ -11,7 +11,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
     GIBBS_start=1 #*#
     
     IDs=names(y)
-    if (!(response_type %in% c("gaussian", "ordinal")))  stop(" Only gaussian and ordinal responses are allowed\n")
+    if (!(response_type %in% c("gaussian", "ordinal")))  stop(" Only gaussian and ordinal responses are allowed")
 
     if (saveAt == "") {
         saveAt = paste(getwd(), "/", sep = "")
@@ -34,7 +34,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
 		groupLabels=names(countGroups)
                 groups=as.integer(groups)
                 ggg=as.integer(groups-1);  #In C we begin to count in 0
-		if(sum(countGroups)!=n) stop("length of groups and y differs, NA's not allowed in groups\n");	
+		if(sum(countGroups)!=n) stop("length of groups and y differs, NA's not allowed in groups");	
     }
 
     if(response_type=="ordinal")
@@ -43,7 +43,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
     	y=factor(y,ordered=TRUE)
         lev=levels(y)
         nclass=length(lev)
-        if(nclass==n) stop("The number of classes in y must be smaller than the number of observations\n");
+        if(nclass==n) stop("The number of classes in y must be smaller than the number of observations");
 
         y=as.integer(y)
         z=y  
@@ -77,8 +77,8 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
         if ((!is.null(a)) | (!is.null(b))) 
         {
             Censored = TRUE
-            if ((length(a) != n) | (length(b) != n)) stop(" y, a and b must have the same dimension\n")
-            if (any(weights != 1)) stop(" Weights are only implemented for Gausian uncensored responses\n")
+            if ((length(a) != n) | (length(b) != n)) stop(" y, a and b must have the same dimension")
+            if (any(weights != 1)) stop(" Weights are only implemented for Gausian uncensored responses")
         }
         mu = weighted.mean(x = y, w = weights, na.rm = TRUE)
     }
@@ -98,11 +98,11 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
 
     if (response_type == "ordinal") {
         if(verbose){ cat(" Prior for residual is not necessary, if you provided it, it will be ignored\n")}
-        if (any(weights != 1)) stop(" Weights are not supported \n")
+        if (any(weights != 1)) stop(" Weights are not supported")
        
         countsZ=table(z)
 
-        if (nclass <= 1) stop(paste(" Data vector y has only ", nclass, " differente values, it should have at least 2 different values\n"))
+        if (nclass <= 1) stop(paste(" Data vector y has only ", nclass, " differente values, it should have at least 2 different values"))
         threshold=qnorm(p=c(0,cumsum(as.vector(countsZ)/n)))
           
         y = rtrun(mu =0, sigma = 1, a = threshold[z], b = threshold[ (z + 1)])
@@ -187,7 +187,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
 
             if(!is.null(groups))
             {
-		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop(paste(" Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented for groups\n", sep = ""))
+		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop(paste(" Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented for groups", sep = ""))
             }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -124,9 +124,9 @@ write_bed=function(x,n,p,bed_file)
 {
    	#Check inputs
 
-   	if(!is.numeric(x)) stop("x should be an integer and numeric\n");
-   	if(min(x)<0) stop("Supported codes are 0,1,2,3\n");
-   	if(max(x)>3) stop("Supported codes are 0,1,2,3\n");
+   	if(!is.numeric(x)) stop("x should be an integer and numeric");
+   	if(min(x)<0) stop("Supported codes are 0,1,2,3");
+   	if(max(x)>3) stop("Supported codes are 0,1,2,3");
    	if(n<=0) stop("n should be bigger than 0");
    	if(p<=0) stop("p should be bigger than 0");
    	if(length(x)!=n*p) stop("length of x is not equal to n*p");

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,7 +52,7 @@ getVariances<-function(X,B,sets,verbose=TRUE)
 			yHat=yHat+uHat
 		}
 
-		if(verbose){ cat(' Working iteration',i,'(out of',nIter,')\n')}
+		if(verbose){ message(' Working iteration ',i,' (out of ',nIter,' )')}
 		VAR[i,(nSets+1)]<-var(yHat)
 	}
 	return(VAR)


### PR DESCRIPTION
Using `cat` is considered bad practice these days as messages cannot be ignored. One of `message`, `warning` or `stop` should be used. They can then be suppressed using `suppressMessages` and `suppressWarnings`. All methods have `paste0` semantics.
