### PR TITLE
Add inst/CITATION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,3 +15,4 @@ Repository/R-Forge/Revision: 78
 Repository/R-Forge/DateTimeStamp: 2013-10-22 13:52:58
 Date/Publication: 2015-04-07 19:14:48
 NeedsCompilation: yes
+Encoding: UTF-8

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,21 @@
+citHeader("To cite BGLR in publications use:")
+
+citEntry(
+    entry = "Article",
+    title = "Genome-Wide Regression and Prediction with the BGLR Statistical Package",
+    author = c(
+        person("Paulino", "Pérez"),
+        person("Gustavo", "de los Campos")
+    ),
+    journal = "Genetics",
+    year = "2014",
+    volume = "198",
+    number = "2",
+    pages = "483--495",
+    url = "http://www.genetics.org/content/198/2/483",
+    textVersion = paste(
+        "Pérez, P., and de los Campos, G., 2014 ",
+        "Genome-Wide Regression and Prediction with the BGLR Statistical Package.",
+        "Genetics 198 (2): 483-495."
+    )
+)


### PR DESCRIPTION
Current output of `citation("BGLR")`:

```
To cite package ‘BGLR’ in publications use:

  Gustavo de los Campos and Paulino Perez Rodriguez, (2015). BGLR:
  Bayesian Generalized Linear Regression. R package version 1.0.5.
  https://CRAN.R-project.org/package=BGLR

A BibTeX entry for LaTeX users is

  @Manual{,
    title = {BGLR: Bayesian Generalized Linear Regression},
    author = {Gustavo de los Campos and Paulino Perez Rodriguez,},
    year = {2015},
    note = {R package version 1.0.5},
    url = {https://CRAN.R-project.org/package=BGLR},
  }

ATTENTION: This citation information has been auto-generated from the
package DESCRIPTION file and may need manual editing, see
‘help("citation")’.
```

New output of `citation("BGLR")`:

```
To cite BGLR in publications use:

  Pérez, P., and de los Campos, G., 2014 Genome-Wide Regression and
  Prediction with the BGLR Statistical Package. Genetics 198 (2):
  483-495.

A BibTeX entry for LaTeX users is

  @Article{,
    title = {Genome-Wide Regression and Prediction with the BGLR Statistical Package},
    author = {Paulino Pérez and Gustavo {de los Campos}},
    journal = {Genetics},
    year = {2014},
    volume = {198},
    number = {2},
    pages = {483--495},
    url = {http://www.genetics.org/content/198/2/483},
  }

Warning message:
'DESCRIPTION' file has an 'Encoding' field and re-encoding is not possible
```

The `Encoding` field in DESCRIPTION is necessary so that it doesn't fail on "Pérez".