### PR TITLE
Import truncnorm::rtruncnorm correctly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Date: 2016-08-19
 Title: Bayesian Generalized Linear Regression
 Author: Gustavo de los Campos, Paulino Perez Rodriguez,
 Maintainer: Paulino Perez Rodriguez <perpdgo@colpos.mx>
-Depends: R (>= 2.10), truncnorm
+Depends: R (>= 2.10)
+Imports: truncnorm
 Description: Bayesian Generalized Linear Regression.
 LazyLoad: true
 License: GPL-3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,6 +6,7 @@ importFrom("stats", "cor", "dbeta", "dchisq", "dexp", "dgamma",
            "rbeta", "rbinom", "rchisq", "rgamma", "rnorm", "runif",
            "var", "weighted.mean")
 importFrom("utils", "read.table")
+importFrom("truncnorm", "rtruncnorm")
 
 export(BGLR,BLR, BGLR2,
        read_bed,read_ped, write_bed,readBinMat,getVariances)


### PR DESCRIPTION
No need for `Depends`. `importFrom()` is needed to satisfy `R CMD check`.