### PR TITLE
Compress saved effects (based on on-the-fly compression)

### DIFF
--- a/R/BGLR.R
+++ b/R/BGLR.R
@@ -206,7 +206,7 @@ setLT.BRR=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,groups,nGroups
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }#*#
@@ -300,7 +300,7 @@ setLT.BRR_sets=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,t
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }
@@ -461,7 +461,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }#*#
@@ -745,7 +745,7 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }#*#
@@ -846,7 +846,7 @@ setLT.BayesA=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose,thi
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }#*#

--- a/R/BGLR2.R
+++ b/R/BGLR2.R
@@ -281,7 +281,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
           			if(ETA[[i]]$saveEffects){
     					fname=paste(saveAt,ETA[[i]]$Name,"_b.bin",sep="")
     					if(rmExistingFiles){ unlink(fname) }
-    					ETA[[i]]$fileEffects=file(fname,open='wb')
+    					ETA[[i]]$fileEffects=gzfile(fname,open='wb')
     					nRow=floor((nIter-burnIn)/thin)
     					writeBin(object=c(nRow,ETA[[i]]$p),con=ETA[[i]]$fileEffects)
     				}
@@ -317,7 +317,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
 			
 			if(ETA[[i]]$saveEffects){
 				fname=paste(saveAt,ETA[[i]]$Name,"_b.bin",sep="")
-    				ETA[[i]]$fileEffects=file(fname,open='ab')
+    				ETA[[i]]$fileEffects=gzfile(fname,open='ab')
 			}
 		}
 	}

--- a/R/BLRCross.R
+++ b/R/BLRCross.R
@@ -93,7 +93,7 @@ setLT.BayesA.Cross=function(prior,y,j,p,idColumns,sumVarX,R2,nLT,verbose,
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }#*#
@@ -221,7 +221,7 @@ setLT.BayesB.Cross=function(prior,y,j,p,idColumns,sumVarX,R2,nLT,verbose,
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }#*#
@@ -339,7 +339,7 @@ setLT.BayesC.Cross=function(prior,y,j,p,idColumns,sumVarX,R2,nLT,verbose,
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }#*#
@@ -527,7 +527,7 @@ setLT.SSVS.Cross=function(prior,y,j,p,idColumns,sumVarX,R2,nLT,verbose,
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }#*#
@@ -610,7 +610,7 @@ setLT.BRR.Cross=function(prior,y,j,p,idColumns,sumVarX,R2,nLT,verbose,
     	if(is.null(LT$thin)){ LT$thin=thin }
     	fname=paste(saveAt,LT$Name,"_b.bin",sep="")
     	if(rmExistingFiles){ unlink(fname) }
-    	LT$fileEffects=file(fname,open='wb')
+    	LT$fileEffects=gzfile(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
     	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
     }#*#

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,7 @@
 
  readBinMat=function(filename,byrow=TRUE){
  	## Function to read effects saved by BGLR when ETA[[j]]$saveEffects=TRUE
-  	fileIn=file(filename,open='rb')
+  	fileIn=gzfile(filename,open='rb')
  	n=readBin(fileIn,n=1,what=numeric())
  	p=readBin(fileIn,n=1,what=numeric())
  	tmp=readBin(fileIn,n=(n*p),what=numeric())
@@ -14,7 +14,7 @@
     n=nrow(x)
     p=ncol(x)
     x=as.vector(x)
-    fileOut<-file(file,open='rb')
+    fileOut<-gzfile(file,open='rb')
     writeBin(object=n,con=fileOut)
     writeBin(object=p,con=fileOut)
     writeBin(object=x,con=fileOut)


### PR DESCRIPTION
This is an ongoing effort, do not merge yet.

This first attempt compresses effects on the fly using `gzfile()`, adding a small penalty per iteration. `gzfile()` can read uncompressed files as well, so `readBinMat()` is backward-compatible.