### PR TITLE
Drop R version test

### DIFF
--- a/R/BGLR.R
+++ b/R/BGLR.R
@@ -924,9 +924,6 @@ metropLambda=function (tau2, lambda, shape1 = 1.2, shape2 = 1.2, max = 200, ncp 
 #this function is executed once the library is loaded
 .onAttach = function(library, pkg)
 {
-  Rv = R.Version()
-  if(!exists("getRversion", baseenv()) || (getRversion() < "3.5.0"))
-    stop("This package requires R 3.5.0 or later")
   if(interactive())
   {
     packageStartupMessage("# Gustavo de los Campos & Paulino Perez-Rodriguez")


### PR DESCRIPTION
`R CMD build`, `R CMD INSTALL`, and `install.packages()` check R version requirement specified in the `DESCRIPTION` file, so having runtime checks in `.onAttach()` is unnecessary. Besides, these tests would only run when the package is loaded via `library()` and not when loaded via `requireNamespace()` or `::`.

R CMD build:
```
$ R CMD build BGLR-R/
* checking for file ‘BGLR-R/DESCRIPTION’ ... OK
* preparing ‘BGLR’:
* checking DESCRIPTION meta-information ... OK
* cleaning src
* installing the package to build vignettes
      -----------------------------------
ERROR: this R is version 3.4.3, package 'BGLR' requires R >= 3.5.0
      -----------------------------------
ERROR: package installation failed
```

R CMD INSTALL:
```
$ R CMD INSTALL BGLR_1.0.8.tar.gz
* installing to library ‘...’
ERROR: this R is version 3.4.3, package 'BGLR' requires R >= 3.5.0
```

install.packages():
```
> install.packages("BGLR")
  Warning message:
  package ‘BGLR’ is not available (for R version 3.4.3)
```