### PR TITLE
Allow to set size of saved effects

### DIFF
--- a/R/BGLR.R
+++ b/R/BGLR.R
@@ -208,7 +208,7 @@ setLT.BRR=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,groups,nGroups
     	if(rmExistingFiles){ unlink(fname) }
     	LT$fileEffects=file(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
-    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
+    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects,size=LT$sizeEffects)
     }#*#
 
     return(LT)
@@ -302,7 +302,7 @@ setLT.BRR_sets=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,t
     	if(rmExistingFiles){ unlink(fname) }
     	LT$fileEffects=file(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
-    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
+    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects,size=LT$sizeEffects)
     }
     return(LT)
 }
@@ -463,7 +463,7 @@ setLT.BL=function(LT,y,n,j,weights,nLT,R2,saveAt,rmExistingFiles,verbose,thin,nI
     	if(rmExistingFiles){ unlink(fname) }
     	LT$fileEffects=file(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
-    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
+    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects,size=LT$sizeEffects)
     }#*#
     
     return(LT)
@@ -747,7 +747,7 @@ setLT.BayesBandC=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles, groups
     	if(rmExistingFiles){ unlink(fname) }
     	LT$fileEffects=file(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
-    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
+    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects,size=LT$sizeEffects)
     }#*#
   
   #return object
@@ -848,7 +848,7 @@ setLT.BayesA=function(LT,y,n,j,weights,saveAt,R2,nLT,rmExistingFiles,verbose,thi
     	if(rmExistingFiles){ unlink(fname) }
     	LT$fileEffects=file(fname,open='wb')
     	nRow=floor((nIter-burnIn)/LT$thin)
-    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects)
+    	writeBin(object=c(nRow,LT$p),con=LT$fileEffects,size=LT$sizeEffects)
     }#*#
   
   #return object
@@ -1238,6 +1238,12 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
             if(!is.null(groups))
             {
 		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop("Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented for groups")
+            }
+
+            if(!is.null(ETA[[i]]$sizeEffects)){
+                if(!(ETA[[i]]$sizeEffects %in% c(4L,8L))) stop("Error in ETA[[", i, "]]", " sizeEffects can be either '4' (single) or '8' (double, default)")
+            }else{
+                ETA[[i]]$sizeEffects=8L
             }
 
 
@@ -1630,7 +1636,9 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_b2 = ETA[[j]]$post_b2 * k + (ETA[[j]]$b^2)/nSums
                       ETA[[j]]$post_varB = ETA[[j]]$post_varB * k + (ETA[[j]]$varB)/nSums
                       ETA[[j]]$post_varB2 = ETA[[j]]$post_varB2 * k + (ETA[[j]]$varB^2)/nSums
-                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects)}#*#
+                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
 
                     if (ETA[[j]]$model == "BRR_sets") {
@@ -1640,7 +1648,9 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_varB2 = ETA[[j]]$post_varB2 * k + (ETA[[j]]$varB^2)/nSums
                       ETA[[j]]$post_varSets<-ETA[[j]]$post_varSets*k+ETA[[j]]$varSets/nSums
                       ETA[[j]]$post_varSets2<-ETA[[j]]$post_varSets2*k+(ETA[[j]]$varSets^2)/nSums
-                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects)}#*#
+                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
                     
                     if (ETA[[j]]$model == "BL") {
@@ -1648,7 +1658,9 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_b2 = ETA[[j]]$post_b2 * k + (ETA[[j]]$b^2)/nSums
                       ETA[[j]]$post_tau2 = ETA[[j]]$post_tau2 * k + (ETA[[j]]$tau2)/nSums
                       ETA[[j]]$post_lambda = ETA[[j]]$post_lambda * k + (ETA[[j]]$lambda)/nSums
-                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects)}#*#
+                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
 
                     if (ETA[[j]]$model == "RKHS") {
@@ -1667,7 +1679,9 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_d = ETA[[j]]$post_d * k + (ETA[[j]]$d)/nSums
                       ETA[[j]]$post_probIn = ETA[[j]]$post_probIn * k + (ETA[[j]]$probIn)/nSums
                       ETA[[j]]$post_probIn2 = ETA[[j]]$post_probIn2 * k + (ETA[[j]]$probIn^2)/nSums
-                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b*ETA[[j]]$d,con=ETA[[j]]$fileEffects)}#*#
+                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b*ETA[[j]]$d,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
 
                     if (ETA[[j]]$model == "BayesA") {
@@ -1677,7 +1691,9 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_varB2 = ETA[[j]]$post_varB2 * k + (ETA[[j]]$varB^2)/nSums
                       ETA[[j]]$post_S = ETA[[j]]$post_S * k + (ETA[[j]]$S)/nSums
 		      		  ETA[[j]]$post_S2 = ETA[[j]]$post_S2 * k + (ETA[[j]]$S^2)/nSums
-		      		  if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects)}#*#
+		      		  if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
 
                     if(ETA[[j]]$model=="BayesB")
@@ -1691,7 +1707,9 @@ BGLR=function (y, response_type = "gaussian", a = NULL, b = NULL,
                         ETA[[j]]$post_probIn2 = ETA[[j]]$post_probIn2 * k + (ETA[[j]]$probIn^2)/nSums
                         ETA[[j]]$post_S = ETA[[j]]$post_S * k + (ETA[[j]]$S)/nSums
 						ETA[[j]]$post_S2 = ETA[[j]]$post_S2 * k + (ETA[[j]]$S^2)/nSums
-						if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b*ETA[[j]]$d,con=ETA[[j]]$fileEffects)}#*#
+						if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                            writeBin(object=ETA[[j]]$b*ETA[[j]]$d,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                        }#*#
                     }
                   }
                 }

--- a/R/BGLR2.R
+++ b/R/BGLR2.R
@@ -190,6 +190,11 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
 		if(!(ETA[[i]]$model %in%  c("BRR","FIXED","BayesB","BayesC"))) stop(paste(" Error in ETA[[", i, "]]", " model ", ETA[[i]]$model, " not implemented for groups\n", sep = ""))
             }
 
+            if(!is.null(ETA[[i]]$sizeEffects)){
+                if(!(ETA[[i]]$sizeEffects %in% c(4L,8L))) stop("Error in ETA[[", i, "]]", " sizeEffects can be either '4' (single) or '8' (double, default)")
+            }else{
+                ETA[[i]]$sizeEffects=8L
+            }
 
             ETA[[i]] = switch(ETA[[i]]$model, 
 			      FIXED = setLT.Fixed(LT = ETA[[i]],  n = n, j = i, weights = weights, y = y, nLT = nLT, saveAt = saveAt, rmExistingFiles = rmExistingFiles,groups=groups,nGroups=nGroups), 
@@ -283,7 +288,7 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
     					if(rmExistingFiles){ unlink(fname) }
     					ETA[[i]]$fileEffects=file(fname,open='wb')
     					nRow=floor((nIter-burnIn)/thin)
-    					writeBin(object=c(nRow,ETA[[i]]$p),con=ETA[[i]]$fileEffects)
+    					writeBin(object=c(nRow,ETA[[i]]$p),con=ETA[[i]]$fileEffects,size=ETA[[i]]$sizeEffects)
     				}
     			}
          	}
@@ -695,7 +700,9 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_b2 = ETA[[j]]$post_b2 * k + (ETA[[j]]$b^2)/nSums
                       ETA[[j]]$post_varB = ETA[[j]]$post_varB * k + (ETA[[j]]$varB)/nSums
                       ETA[[j]]$post_varB2 = ETA[[j]]$post_varB2 * k + (ETA[[j]]$varB^2)/nSums
-                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects)}#*#
+                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
 
                     if (ETA[[j]]$model == "BRR_sets") {
@@ -705,7 +712,9 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_varB2 = ETA[[j]]$post_varB2 * k + (ETA[[j]]$varB^2)/nSums
                       ETA[[j]]$post_varSets<-ETA[[j]]$post_varSets*k+tmp/nSums
                       ETA[[j]]$post_varSets2<-ETA[[j]]$post_varSets2*k+(tmp^2)/nSums
-                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects)}#*#
+                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
                     
                     if (ETA[[j]]$model == "BL") {
@@ -713,7 +722,9 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_b2 = ETA[[j]]$post_b2 * k + (ETA[[j]]$b^2)/nSums
                       ETA[[j]]$post_tau2 = ETA[[j]]$post_tau2 * k + (ETA[[j]]$tau2)/nSums
                       ETA[[j]]$post_lambda = ETA[[j]]$post_lambda * k + (ETA[[j]]$lambda)/nSums
-                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects)}#*#
+                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
 
                     if (ETA[[j]]$model == "RKHS") {
@@ -732,7 +743,9 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_d = ETA[[j]]$post_d * k + (ETA[[j]]$d)/nSums
                       ETA[[j]]$post_probIn = ETA[[j]]$post_probIn * k + (ETA[[j]]$probIn)/nSums
                       ETA[[j]]$post_probIn2 = ETA[[j]]$post_probIn2 * k + (ETA[[j]]$probIn^2)/nSums
-                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b*ETA[[j]]$d,con=ETA[[j]]$fileEffects)}#*#
+                      if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b*ETA[[j]]$d,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
 
                     if (ETA[[j]]$model == "BayesA") {
@@ -742,7 +755,9 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
                       ETA[[j]]$post_varB2 = ETA[[j]]$post_varB2 * k + (ETA[[j]]$varB^2)/nSums
                       ETA[[j]]$post_S = ETA[[j]]$post_S * k + (ETA[[j]]$S)/nSums
 		      		  ETA[[j]]$post_S2 = ETA[[j]]$post_S2 * k + (ETA[[j]]$S^2)/nSums
-		      		  if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects)}#*#
+		      		  if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                          writeBin(object=ETA[[j]]$b,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                      }#*#
                     }
 
                     if(ETA[[j]]$model=="BayesB")
@@ -756,7 +771,9 @@ BGLR2=function (y, response_type = "gaussian", a = NULL, b = NULL,
                         ETA[[j]]$post_probIn2 = ETA[[j]]$post_probIn2 * k + (ETA[[j]]$probIn^2)/nSums
                         ETA[[j]]$post_S = ETA[[j]]$post_S * k + (ETA[[j]]$S)/nSums
 						ETA[[j]]$post_S2 = ETA[[j]]$post_S2 * k + (ETA[[j]]$S^2)/nSums
-						if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){  writeBin(object=ETA[[j]]$b*ETA[[j]]$d,con=ETA[[j]]$fileEffects)}#*#
+						if(ETA[[j]]$saveEffects&&(i%%ETA[[j]]$thin)==0){
+                            writeBin(object=ETA[[j]]$b*ETA[[j]]$d,con=ETA[[j]]$fileEffects,size=ETA[[j]]$sizeEffects)
+                        }#*#
                     }
                   }
                 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,23 +1,29 @@
 
- readBinMat=function(filename,byrow=TRUE){
+ readBinMat=function(filename,byrow=TRUE,size=8L){
+    if(!size %in% c(4L,8L)){
+        stop("size can either be 4 (single) or 8 (double, default)")
+    }
  	## Function to read effects saved by BGLR when ETA[[j]]$saveEffects=TRUE
   	fileIn=file(filename,open='rb')
- 	n=readBin(fileIn,n=1,what=numeric())
- 	p=readBin(fileIn,n=1,what=numeric())
- 	tmp=readBin(fileIn,n=(n*p),what=numeric())
+ 	n=readBin(fileIn,n=1,what=numeric(),size=size)
+ 	p=readBin(fileIn,n=1,what=numeric(),size=size)
+ 	tmp=readBin(fileIn,n=(n*p),what=numeric(),size=size)
  	X=matrix(data=tmp,nrow=n,ncol=p,byrow=byrow)
  	close(fileIn)
  	return(X)
  }
  
- writeBinMat=function(x,file,byrow=T){
+ writeBinMat=function(x,file,byrow=T,size=8L){
+    if(!size %in% c(4L,8L)){
+        stop("size can either be 4 (single) or 8 (double, default)")
+    }
     n=nrow(x)
     p=ncol(x)
     x=as.vector(x)
     fileOut<-file(file,open='rb')
-    writeBin(object=n,con=fileOut)
-    writeBin(object=p,con=fileOut)
-    writeBin(object=x,con=fileOut)
+    writeBin(object=n,con=fileOut,size=size)
+    writeBin(object=p,con=fileOut,size=size)
+    writeBin(object=x,con=fileOut,size=size)
     close(fileOut)
  }
  

--- a/man/readBinMat.Rd
+++ b/man/readBinMat.Rd
@@ -6,13 +6,14 @@
 }
 \usage{
 
-	readBinMat(filename,byrow=TRUE)
+	readBinMat(filename,byrow=TRUE,size=8L)
 
 }
 \arguments{
 
 	\item{filename}{(string), the name of the file to be read.}
 	\item{byrow}{(logical), if TRUE the matrix is created by filling its corresponding elements by rows.}
+	\item{size}{(integer), the size used to save effects via ETA[[j]]$sizeEffects: '8' if double (default), or '4' if single.}
 }
 
 \value{


### PR DESCRIPTION
I have added a new LT option called `sizeEffects` that will allow to set the size of saved effects to either single (`4`) or double (`8`, default), plus a corresponding `size` parameter to `readBinMat()` and `writeBinMat()`.

I'm not terribly happy with the name as this might be confused with "effect size" or something, but "precision" is not much better here. Also the numbers might be confusing, but it's useful to have them to avoid too many `ifelse()`s in the sampler (we could retype from character to integer before the Gibbs sampler runs, or use another entry in LT that contains the mapped value instead). What do you think?