### PR TITLE
write_bed: Fix potential integer overflow

### DIFF
--- a/src/util_plink.c
+++ b/src/util_plink.c
@@ -501,7 +501,7 @@ void write_bed_(char **bed_file, int *n, int *p, int *out)
                         for(i=0; i<*n; i++)
                         { 
                                 l++;
-                                mask=recode[out[i+j*(*n)]] << 2 * l;
+                                mask=recode[out[i+(long long)j*(*n)]] << 2 * l;
                                 byte = byte | mask ;
                                 if((i+1)%4==0)
                                 {


### PR DESCRIPTION
In the best case we are getting a segfault for large input matrices, but I am more concerned about compilers that wrap around and then produce incorrect output.